### PR TITLE
Develop

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -26,6 +26,7 @@ open Fake.ZipHelper
 #load "src/Components/Autocomplete.fs"
 #load "src/Components/Tooltips.fs"
 #load "src/Components/Highlight.fs"
+#load "src/Components/Toolbar.fs"
 #load "src/Components/Errors.fs"
 #load "src/Components/FindDeclaration.fs"
 #load "src/Components/FAKE.fs"

--- a/src/Atom.FSharp.Generator.fsproj
+++ b/src/Atom.FSharp.Generator.fsproj
@@ -55,6 +55,7 @@
     <Compile Include="Components\Parser.fs" />
     <Compile Include="Components\Autocomplete.fs" />
     <Compile Include="Components\Tooltips.fs" />
+    <Compile Include="Components\Toolbar.fs" />
     <Compile Include="Components\Highlight.fs" />
     <Compile Include="Components\Errors.fs" />
     <Compile Include="Components\FindDeclaration.fs" />

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -14,11 +14,13 @@ module ErrorPanel =
     let mutable private panel : IPanel option = None
     let private subscriptions = ResizeArray()
 
+//                  <span>Errors</span>
+
     let private create () =
         "<div class='tool-panel panel-bottom error-pane' id='pane'>
-                <div class='inset-panel'>
+            <div class='inset-panel'>
                 <div class='panel-heading clearfix' style='height: 30px'>
-                  <span>Errors</span>
+                  <span>Dev-Errors</span>
                   <span id='btnMin' class='icon-min' style='float:right'></span>
                   <span id='btnMax' class='icon-max' style='float:right; display: none'></span>
                 </div>
@@ -71,6 +73,7 @@ module ErrorPanel =
             let t = create ()
             Globals.atom.workspace.addBottomPanel (unbox<AnonymousType499>{PanelOptions.item = t; PanelOptions.priority = 100; PanelOptions.visible = false})
         panel <- Some p
+       
         addMinimize()
         Globals.atom.workspace.getActiveTextEditor() |> handleEditorChange p
 

--- a/src/Components/Toolbar.fs
+++ b/src/Components/Toolbar.fs
@@ -1,0 +1,106 @@
+﻿namespace Atom.FSharp
+
+
+open FunScript
+open FunScript.TypeScript
+open FunScript.TypeScript.fs
+open FunScript.TypeScript.child_process
+open FunScript.TypeScript.AtomCore
+open FunScript.TypeScript.text_buffer
+
+open Atom
+open Atom.FSharp
+
+[<ReflectedDefinition>]
+module ToolbarHandler =
+
+    let mutable private ed  = createEmpty<IEditor>()
+    let mutable private bar = createEmpty<IPanel>()
+    let private subscriptions = ResizeArray()
+    let mutable cursorSubscription : IDisposable option = None
+
+
+    // Create toolbar to display the type signature of the symbol under the cursor
+    let private createToolbar () =
+        "<div class='type-toolbar panel-bottom type-pane' id='pane' style='height: 20px'>
+            <div class='toolbar-inner'></div>
+        </div>"
+        |> jq
+
+    let private getCursor (editor:IEditor) =
+        let bufferPt = editor.getCursorBufferPosition()
+        { row = bufferPt.row; column = bufferPt.column }
+
+    /// Makes request for toolbar informations
+    let private askForToolbar (editor : IEditor)  =
+        if unbox<obj>(editor.buffer.file) <> null then
+            let pos = getCursor editor
+            let path = editor.buffer.file.path
+            LanguageService.toolbar path (int pos.row + 1) (int pos.column + 1)
+        ()
+
+    // Because the type signature for classes is multiple lines and will not fit
+    // within the toolbar we cut out the list of members and properties
+    let format_data (tinfo:string) = 
+        let ti  =tinfo.Trim()
+        if ti.StartsWith("type") then
+            let idx = ti.IndexOf('=')
+            ti.Substring(0,idx-1)
+        else ti
+        |> (+) "> "
+        
+
+    let private cursorHandler (o: DTO.TooltipResult) =
+        let tb = jq(".toolbar-inner")
+        tb.empty() |> ignore
+        if o.Data <> "No tooltip information" then            
+            tb.append(format_data o.Data) |> ignore
+        ()
+
+
+    // Controls whether the type signature toolbar is displayed by checking the syntax grammar in Atom
+    let private handleEditorChange (panel : IPanel) (editor : AtomCore.IEditor)  =
+        if JS.isDefined editor && JS.isPropertyDefined editor "getGrammar" && editor.getGrammar().name = "F#" then
+            panel.show()
+            bar.show()
+        else
+            panel.hide()
+            bar.hide()
+
+    let run exe args = System.Diagnostics.Process.Start( exe, args)
+
+
+
+    let private remove () =
+        cursorSubscription |> Option.iter (fun cs ->
+            cs.dispose()
+            cursorSubscription <- None
+        )
+
+    let private initialize (editor : IEditor) = 
+        remove()
+        if JS.isDefined editor && JS.isPropertyDefined editor "getGrammar" && editor.getGrammar().name = "F#" then
+            ed <- editor
+            cursorSubscription <-  editor.onDidChangeCursorPosition(fun n -> askForToolbar ed ) |> Some
+
+    let activate () =
+        let b =
+            let t = createToolbar ()
+            Globals.atom.workspace.addBottomPanel(unbox<AnonymousType499>{PanelOptions.item = t; PanelOptions.priority = 100; PanelOptions.visible = true})
+        bar <- b
+        Globals.atom.workspace.getActiveTextEditor() |> initialize
+        Globals.atom.workspace.onDidChangeActivePaneItem(fun ed -> initialize ed) |> ignore
+        
+        let tp = Globals.atom.workspace.onDidChangeActivePaneItem(fun ed -> handleEditorChange b ed)
+        subscriptions.Add tp
+
+        let tb = unbox<Function> cursorHandler |> Events.on Events.Toolbars
+        subscriptions.Add tb
+
+        ()
+
+    let deactivate () =
+        subscriptions |> Seq.iter(fun n -> n.dispose())
+        subscriptions.Clear()
+        cursorSubscription |> Option.iter (fun cs -> cs.dispose())
+        ()

--- a/src/Components/Toolbar.fs
+++ b/src/Components/Toolbar.fs
@@ -67,10 +67,6 @@ module ToolbarHandler =
             panel.hide()
             bar.hide()
 
-    let run exe args = System.Diagnostics.Process.Start( exe, args)
-
-
-
     let private remove () =
         cursorSubscription |> Option.iter (fun cs ->
             cs.dispose()

--- a/src/Core/Bindings.fs
+++ b/src/Core/Bindings.fs
@@ -246,6 +246,9 @@ module Bindings =
         [<FunScript.JSEmitInline("({0}.moveToBeginningOfLine())")>]
         member __.moveToBeginningOfLine() : unit = failwith "JS"
 
+        [<FunScript.JSEmitInline("({0}.onDidChangeCursorPosition({1}))")>]
+        member __.onDidChangeCursorPosition(cb: obj -> unit) : IDisposable = failwith "JS"
+
 
     [<JSEmitInline("{0}.decorateMarker({1}, {type: 'highlight', class: {2}})")>]
     let decorateMarker(ed : IEditor, marker : IDisplayBufferMarker, cls : string) : unit = failwith "JS"

--- a/src/Core/Events.fs
+++ b/src/Core/Events.fs
@@ -23,6 +23,7 @@ module Events =
         | Errors
         | Completion
         | Tooltips
+        | Toolbars
         | FindDecl
         | Status
         | CompilerLocation
@@ -35,6 +36,7 @@ module Events =
         | Errors -> "Fsharp_errors"
         | Completion -> "Fsharp_completion"
         | Tooltips -> "FSharp_tooltips"
+        | Toolbars -> "FSharp_toolbars"
         | FindDecl -> "FSharp_finddecl"
         | Project -> "Fsharp_project"
         | Status -> "Fsharp_status"

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -50,6 +50,10 @@ module LanguageService =
                 elif s.Contains "\"Kind\":\"tooltip\"" then
                     s |> Events.parseAndEmit<DTO.TooltipResult> Events.Tooltips
                     last <- Events.Tooltips
+                elif s.Contains "\"Kind\":\"toolbar\"" then
+                    s |> Events.parseAndEmit<DTO.TooltipResult> Events.Toolbars
+                    last <- Events.Toolbars
+
                 elif s.Contains "\"Kind\":\"finddecl\"" then
                     s |> Events.parseAndEmit<DTO.TooltipResult> Events.FindDecl
                     last <- Events.FindDecl
@@ -120,6 +124,11 @@ module LanguageService =
     let tooltip fn line col =
         let str = sprintf "tooltip \"%s\" %d %d\n" fn line col
         ask str
+
+    let toolbar fn line col =
+        let str = sprintf "toolbar \"%s\" %d %d\n" fn line col
+        ask str
+
 
     let findDeclaration fn line col =
         let str = sprintf "finddecl \"%s\" %d %d\n" fn line col

--- a/src/FSharpIDE.fs
+++ b/src/FSharpIDE.fs
@@ -27,8 +27,9 @@ type FSharpIDE() =
 
         Parser.activate ()
         HighlighterHandler.activate ()
-        ErrorPanel.activate ()
         TooltipHandler.activate ()     // needs to follow error panel so it appears above it
+        ErrorPanel.activate ()
+        ToolbarHandler.activate()
         FindDeclaration.activate ()
         FAKE.activate ()
         Interactive.activate ()
@@ -39,6 +40,7 @@ type FSharpIDE() =
         TooltipHandler.deactivate ()
         HighlighterHandler.deactivate ()
         ErrorPanel.deactivate ()
+        ToolbarHandler.deactivate()
         FindDeclaration.deactivate ()
         FAKE.deactivate ()
         Interactive.deactivate ()

--- a/src/FSharpIDE.fs
+++ b/src/FSharpIDE.fs
@@ -27,9 +27,9 @@ type FSharpIDE() =
 
         Parser.activate ()
         HighlighterHandler.activate ()
-        TooltipHandler.activate ()     // needs to follow error panel so it appears above it
+        TooltipHandler.activate ()     
         ErrorPanel.activate ()
-        ToolbarHandler.activate()
+        ToolbarHandler.activate()             // needs to follow error panel so it appears above it
         FindDeclaration.activate ()
         FAKE.activate ()
         Interactive.activate ()

--- a/src/FSharpIDE.fs
+++ b/src/FSharpIDE.fs
@@ -26,9 +26,9 @@ type FSharpIDE() =
         do LanguageService.start ()
 
         Parser.activate ()
-        TooltipHandler.activate ()
         HighlighterHandler.activate ()
         ErrorPanel.activate ()
+        TooltipHandler.activate ()     // needs to follow error panel so it appears above it
         FindDeclaration.activate ()
         FAKE.activate ()
         Interactive.activate ()


### PR DESCRIPTION
Toolbar has it's own module
Type signatures are truncated for classes 
Toolbar appears and hides based on syntax grammar 