### PR TITLE
Change keymap selector

### DIFF
--- a/src/atom-fsharp/keymaps/core.cson
+++ b/src/atom-fsharp/keymaps/core.cson
@@ -8,7 +8,7 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 
-'atom-text-editor[data-grammar~=fsharp]':
+'atom-workspace atom-text-editor:not([mini])[data-grammar~=fsharp]':
     'alt-enter': 'FSI:Send-Selection'
     'alt-/':'FSI:Send-Line'
     'ctrl-space': 'fsharp:autocomplete'


### PR DESCRIPTION
Continuing from https://github.com/fsprojects/atom-fsharp/issues/79
This PR changes the selector in keymaps cson, and fixes the issue with alt-enter in OSX.
I've tested this in OSX and Windows (I don't have a linux box), and works without a problem.

It seems that both typescript and omnisharp use this selector (i.e. excluding mini editor):
* https://github.com/TypeStrong/atom-typescript/blob/master/keymaps/atom-typescript.cson#L1
* https://github.com/OmniSharp/omnisharp-atom/blob/master/keymaps/omnisharp-atom.cson#L18