### PR TITLE
Add .comment prefix to autocomplete blacklist

### DIFF
--- a/src/Components/Autocomplete.fs
+++ b/src/Components/Autocomplete.fs
@@ -74,4 +74,4 @@ module AutocompleteProvider =
         Globals.atom.commands.add("atom-text-editor","fsharp:autocomplete", (fun _ ->
             dispatchAutocompleteCommand ()
             isForced <- true) |> unbox<Function>) |> ignore
-        { selector = ".source.fsharp"; disableForSelector = ".source.fsharp .string"; inclusionPriority = 1; excludeLowerPriority = true; getSuggestions = getSuggestion}
+        { selector = ".source.fsharp"; disableForSelector = ".source.fsharp .string, .source.fsharp .comment"; inclusionPriority = 1; excludeLowerPriority = true; getSuggestions = getSuggestion}


### PR DESCRIPTION
This should suppress occurrences of autocompletion in both block comments `(* ... *)` and line comments `//`