### PR TITLE
Small fix for symboluse

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -135,7 +135,7 @@ module LanguageService =
         ask str
 
     let symbolUse fn line col =
-        let str = sprintf "symboluse \"%s\" %d %d" fn line col
+        let str = sprintf "symboluse \"%s\" %d %d\n" fn line col
         ask str
 
     let tooltip fn line col =


### PR DESCRIPTION
I forgot a \n when sending the `symboluse` command. This gave a delay before seeing the highlight, as well as ruining the next command (usually a parse).