### PR TITLE
Fix keybindings to work with Nordic OS-X keyboards

### DIFF
--- a/src/atom-fsharp/keymaps/core.cson
+++ b/src/atom-fsharp/keymaps/core.cson
@@ -10,11 +10,13 @@
 
 'atom-workspace atom-text-editor:not([mini])[data-grammar~=fsharp]':
     'alt-enter': 'FSI:Send-Selection'
-    'alt-/':'FSI:Send-Line'
     'ctrl-space': 'fsharp:autocomplete'
     'cmd-space': 'fsharp:autocomplete'
 'atom-workspace':
     'f5': 'FAKE:Build-Default'
+
+'.platform-win32 atom-workspace atom-text-editor:not([mini])[data-grammar~=fsharp]':
+    'alt-/':'FSI:Send-Line'
 
 '.platform-darwin atom-workspace atom-text-editor:not([mini])[data-grammar~=fsharp]':
     'ctrl-cmd-l':'FSI:Send-Line'


### PR DESCRIPTION
This fixes #92 for me. The reason is that ```Shift + 7``` equals ```/```, and the universal ```FSI:Send-Line``` catches ```Alt + Shift + 7```, which in turn equals ```\``` on a Nordic/Scandinavian OS-X keymap.