### PR TITLE
Send silent #cd to FSI to support relative #loads etc

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -80,11 +80,10 @@ Target "BuildGenerator" (fun () ->
 )
 
 Target "RunGenerator" (fun () ->
-
-        (TimeSpan.FromMinutes 5.0)
-        |> ProcessHelper.ExecProcess (fun p ->
-            p.FileName <- __SOURCE_DIRECTORY__ @@ "src" @@ "bin" @@ "Debug" @@ "Atom.FSharp.Generator.exe" )
-        |> ignore
+    (TimeSpan.FromMinutes 5.0)
+    |> ProcessHelper.ExecProcess (fun p ->
+        p.FileName <- __SOURCE_DIRECTORY__ @@ "src" @@ "bin" @@ "Debug" @@ "Atom.FSharp.Generator.exe" )
+    |> ignore
 )
 #if MONO
 #else

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ then
   	exit $exit_code
   fi
 
-  packages/FAKE/tools/FAKE.exe $@ --fsiargs --nocache build.fsx 
+  packages/FAKE/tools/FAKE.exe $@ --nocache --fsiargs build.fsx 
 else
   # use mono
   mono .paket/paket.bootstrapper.exe
@@ -29,5 +29,5 @@ else
   if [ $exit_code -ne 0 ]; then
   	exit $exit_code
   fi
-  mono packages/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO --nocache build.fsx
+  mono packages/FAKE/tools/FAKE.exe $@ --nocache --fsiargs -d:MONO build.fsx
 fi

--- a/src/Components/Interactive.fs
+++ b/src/Components/Interactive.fs
@@ -28,6 +28,7 @@ module Interactive =
     let private startFsi () =
         let fs = Process.spawnSame fsipath ""
         fsiProc <- fs |> Some
+        fs.stderr.on ("data", unbox<Function> (handle)) |> ignore
         fs.stdout.on ("data", unbox<Function> (handle)) |> ignore
 
     /// Kills the Fsi Process and reloads the REPL pane

--- a/src/Components/Interactive.fs
+++ b/src/Components/Interactive.fs
@@ -55,11 +55,17 @@ module Interactive =
     // TODO - trying to get it to open the repl if it's not already open
     let private sendToFsi (msg' : string) =
         if fsiProc.IsNone then openFsi()
+        
+        let editor = Globals.atom.workspace.getActiveTextEditor()
+        let dir = Globals.dirname(editor.getPath())
         let msg = msg'.Replace("\uFEFF", "") + ";;\n"
+
         fsiEditor |> Option.iter( fun ed ->
             ed.insertText msg |> ignore
             )
         fsiProc |> Option.iter( fun cproc ->
+            let cd = "#cd \"\"\"" + dir + "\"\"\";;\n"
+            cproc.stdin.write(cd, "utf-8") 
             cproc.stdin.write(msg, "utf-8")
             )
 


### PR DESCRIPTION
The `#cd` command is a hidden F# Interactive command that can be used to tell FSI where to look for relative paths. This is useful when you have, for example, `#load "packages/FsLab/FsLab.fsx` :-)

Aside, do you think it's a good idea to print the F# code sent to F# Interactive in the window? Visual Studio does not do that and I'm quite happy with that.

That said, if the FSI window was HTML frame, we could create some really fancy expandable HTML gadget that would be hidden by default and you could click on it to see the full output. How hard would it be to change the FSI window into a read-only HTML window with some `<pre>` tags in it?