### PR TITLE
fixing build errors on linux

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -73,7 +73,7 @@ let atomPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicat
 
 let apmTool, atomTool =
     #if MONO
-        "apm", atom
+        "apm", "atom"
     #else
         atomPath </> "apm.cmd" , atomPath </> "atom.cmd"
     #endif

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,8 +1,10 @@
 source https://nuget.org/api/v2
 
-git https://github.com/ionide/ionide-helpers.git master build:"build.cmd"
+git https://github.com/ionide/ionide-helpers.git master build:"build.cmd", OS:windows
+git https://github.com/ionide/ionide-helpers.git master build:"build.sh", OS:mono
 git https://github.com/ionide/ionide-fsgrammar.git
-git https://github.com/ionide/FsAutoComplete.git master build:"build.cmd LocalRelease"
+git https://github.com/ionide/FsAutoComplete.git master build:"build.cmd LocalRelease", OS:windows
+git https://github.com/ionide/FsAutoComplete.git master build:"build.sh LocalRelease", OS:mono
 
 nuget FAKE
 nuget FantomasCLI

--- a/paket.lock
+++ b/paket.lock
@@ -1,14 +1,22 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.50)
-    FantomasCLI (2.4)
+    FAKE (4.55)
+    FantomasCLI (2.5)
     FunScript (1.1.94)
 GIT
   remote: https://github.com/ionide/ionide-helpers.git
      (4b14b4667c8f2c866a96adb50f953f02df874085)
       build: build.cmd
+      os: windows
+     (4b14b4667c8f2c866a96adb50f953f02df874085)
+      build: build.sh
+      os: mono
   remote: https://github.com/ionide/ionide-fsgrammar.git
-     (edb05603ec3f2eb3c633f92df1649e82fe870545)
+     (4f7e4e4568d6710b0250c4d9bde26915875aee90)
   remote: https://github.com/ionide/FsAutoComplete.git
-     (0aac468dabb0797ac3ae81d1cec75ba135e2c076)
+     (b3fd0b32fb3fdc5af24a39561134d54ab4eb512a)
       build: build.cmd LocalRelease
+      os: windows
+     (b3fd0b32fb3fdc5af24a39561134d54ab4eb512a)
+      build: build.sh LocalRelease
+      os: mono


### PR DESCRIPTION
I'm running Ubuntu 14.04 and running `build.sh` failed saying it could not execute `build.cmd`

These changes allow me to complete the build successfully.  I can revert the paket.lock version bumps if that is a concern.